### PR TITLE
fix viz.py with python3

### DIFF
--- a/mxgan/viz.py
+++ b/mxgan/viz.py
@@ -9,7 +9,7 @@ def _fill_buf(buf, i, img, shape):
     m = buf.shape[1]/shape[0]
 
     sx = (i%m)*shape[0]
-    sy = (i/m)*shape[1]
+    sy = int((i/m))*shape[1]
     buf[sy:sy+shape[1], sx:sx+shape[0], :] = img
 
 

--- a/mxgan/viz.py
+++ b/mxgan/viz.py
@@ -9,7 +9,7 @@ def _fill_buf(buf, i, img, shape):
     m = buf.shape[1]/shape[0]
 
     sx = (i%m)*shape[0]
-    sy = int((i/m))*shape[1]
+    sy = (i//m)*shape[1]
     buf[sy:sy+shape[1], sx:sx+shape[0], :] = img
 
 


### PR DESCRIPTION
with python3, when train gan_mnist, m=n=28, and when i = 1, then i/m will be `0.357` not `0`